### PR TITLE
Remove duplicated transforms

### DIFF
--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -74,10 +74,6 @@ module.exports = (targetBundle, cnfg, opts) => {
     })
   }
 
-  for(let t of bConfig.transform) {
-    b.transform(t);
-  }
-
   function bundle() {
     let stream = fs.createWriteStream(path.join(targetBasedir, targetOutfileInfo.base));
     logDurration(stream, `bundled ${targetBundle.target} src`);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/jhnstn/bundbi"
   },
   "scripts": {
-    "test": "tape ./tests/**-test.js | tnyan"
+    "test": "tape ./tests/**-test.js | tap-spec"
   },
   "bin": {
     "bundbi": "bin/cli.js"

--- a/tests/bundle-test.js
+++ b/tests/bundle-test.js
@@ -71,11 +71,6 @@ test('bundling' , bundleTest => {
       t.end();
     });
 
-    source.test('adds transforms', t => {
-      t.equal(targetBuild.transform[0], browserifyStub.transform.firstCall.args[0]);
-      t.end();
-    });
-
     source.test('sets externals', t => {
       t.deepEqual(targetBuild.external, browserifyStub.external.firstCall.args[0]);
       t.end();


### PR DESCRIPTION
While investigating #5 I noticed that the transforms were being applied twice per bundle. 
The transforms are added as part of the browserify config [here](https://github.com/jhnstn/bundbi/blob/cae37ae2b9df08cf63aa6626c4ec15de8aeaa286/lib/bundle.js#L68)

This gets the bundle time on par with vanilla browserify
