### PR TITLE
Print error, but don't exit process, when in watch mode

### DIFF
--- a/.github/workflows/gitleaks-check.yaml
+++ b/.github/workflows/gitleaks-check.yaml
@@ -1,0 +1,14 @@
+name: "Secrets Scan"
+
+on:
+  pull_request:
+    
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: '0'
+    - name: Gitleaks
+      uses: zricethezav/gitleaks-action@v1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+# Based off of https://github.com/zricethezav/gitleaks
+repos:
+  - repo: https://github.com/zricethezav/gitleaks
+    rev: v8.2.0
+    hooks:
+      - id: gitleaks

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -75,7 +75,7 @@ module.exports = (targetBundle, cnfg, opts) => {
     })
   }
 
-  function bundle(errorHandler) {
+  function bundle() {
     let stream = fs.createWriteStream(path.join(targetBasedir, targetOutfileInfo.base));
     logDurration(stream, `bundled ${targetBundle.target} src`);
     b.bundle()

--- a/lib/bundle.js
+++ b/lib/bundle.js
@@ -5,6 +5,7 @@ const _ = require('underscore');
 const browserify =  require('browserify');
 const watchify  = require('watchify');
 const exit = require('./exit');
+const watchErrorHandler = require('./watchErrorHandler');
 
 let logDurration = (stream, message) => {
   stream.on('pipe', () => console.time(message));
@@ -74,11 +75,11 @@ module.exports = (targetBundle, cnfg, opts) => {
     })
   }
 
-  function bundle() {
+  function bundle(errorHandler) {
     let stream = fs.createWriteStream(path.join(targetBasedir, targetOutfileInfo.base));
     logDurration(stream, `bundled ${targetBundle.target} src`);
     b.bundle()
-      .on('error', exit)
+      .on('error', bConfig.watch ? watchErrorHandler : exit)
       .pipe(stream);
   }
 

--- a/lib/watchErrorHandler.js
+++ b/lib/watchErrorHandler.js
@@ -2,6 +2,6 @@ module.exports = (message, status) =>  {
   if(status === 0) {
     console.log(message);
   } else {
-    console.error( message.stack ? message.stack : String(message));
+    console.error(message.stack || String(message));
   }
 };

--- a/lib/watchErrorHandler.js
+++ b/lib/watchErrorHandler.js
@@ -1,0 +1,7 @@
+module.exports = (message, status) =>  {
+  if(status === 0) {
+    console.log(message);
+  } else {
+    console.error( message.stack ? message.stack : String(message));
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bundbi",
-  "version": "1.1.10",
+  "version": "1.1.11",
   "description": "bundle builder for browserify",
   "repository": {
     "type": "git",


### PR DESCRIPTION
During normal workflow, it's common to save files with `SyntaxError`s. If you're monitoring your build with e.g. `bundbi app -w -d --poll`, it will try to rebuild the file, raise the `SyntaxError`, and then exit the process.

This change makes it so that, in watch mode only, the process will not die on errors, but instead keep watching for the next change. The saves a lot of time in not having to constantly check to see if the watch process is still alive, and having to restart it, etc.